### PR TITLE
Update function prototypes to use ufsm_status_t

### DIFF
--- a/src/ufsm.h
+++ b/src/ufsm.h
@@ -70,7 +70,7 @@ typedef bool (*ufsm_guard_func_t) (void);
 typedef void (*ufsm_action_func_t) (void);
 typedef void (*ufsm_entry_exit_func_t) (void);
 typedef void (*ufsm_queue_cb_t) (void);
-typedef uint32_t (*ufsm_doact_cb_t) (struct ufsm_machine *m, struct ufsm_state *s);
+typedef ufsm_status_t (*ufsm_doact_cb_t) (struct ufsm_machine *m, struct ufsm_state *s);
 typedef void (*ufsm_doact_func_t) (struct ufsm_machine *m,
                                    struct ufsm_state *s,
                                    ufsm_doact_cb_t cb);

--- a/src/ufsm_queue.c
+++ b/src/ufsm_queue.c
@@ -9,7 +9,7 @@
 
 #include <ufsm.h>
 
-uint32_t ufsm_queue_put(struct ufsm_queue *q, uint32_t ev)
+ufsm_status_t ufsm_queue_put(struct ufsm_queue *q, uint32_t ev)
 {
     uint32_t err = UFSM_OK;
 
@@ -37,7 +37,7 @@ uint32_t ufsm_queue_put(struct ufsm_queue *q, uint32_t ev)
     return err;
 }
 
-uint32_t ufsm_queue_get(struct ufsm_queue *q, uint32_t *ev)
+ufsm_status_t ufsm_queue_get(struct ufsm_queue *q, uint32_t *ev)
 {
     uint32_t err = UFSM_OK;
 
@@ -62,7 +62,7 @@ uint32_t ufsm_queue_get(struct ufsm_queue *q, uint32_t *ev)
     return err;
 }
 
-uint32_t ufsm_queue_init(struct ufsm_queue *q, uint32_t no_of_elements,
+ufsm_status_t ufsm_queue_init(struct ufsm_queue *q, uint32_t no_of_elements,
                                                uint32_t *data)
 {
     q->head = 0;

--- a/src/ufsm_stack.c
+++ b/src/ufsm_stack.c
@@ -9,7 +9,7 @@
 
 #include <ufsm.h>
 
-uint32_t ufsm_stack_init(struct ufsm_stack *stack,
+ufsm_status_t ufsm_stack_init(struct ufsm_stack *stack,
                         uint32_t no_of_elements,
                         void **stack_data)
 {
@@ -20,7 +20,7 @@ uint32_t ufsm_stack_init(struct ufsm_stack *stack,
     return UFSM_OK;
 }
 
-uint32_t ufsm_stack_push(struct ufsm_stack *stack, void *item)
+ufsm_status_t ufsm_stack_push(struct ufsm_stack *stack, void *item)
 {
     if (stack->pos >= stack->no_of_elements)
         return UFSM_ERROR_STACK_OVERFLOW;
@@ -30,7 +30,7 @@ uint32_t ufsm_stack_push(struct ufsm_stack *stack, void *item)
     return UFSM_OK;
 }
 
-uint32_t ufsm_stack_pop(struct ufsm_stack *stack, void **item)
+ufsm_status_t ufsm_stack_pop(struct ufsm_stack *stack, void **item)
 {
     if(!stack->pos)
         return UFSM_ERROR_STACK_UNDERFLOW;


### PR DESCRIPTION
This fixes compiler errors for conflicting function types and incompatible pointer type warnings.