### PR TITLE
docs: fix simple typo, retreve -> retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Functions with highest cyclomatic complexity:
 
 ## Event queue
 The event is implemented as a circular buffer with a 'put' and 'get' function to
-store and retreve data. 
+store and retrieve data. 
 
 The queue has three optional callbacks; 'on_data', 'lock' and 'unlock'. This 
 allowes some flexibility with the target environment.


### PR DESCRIPTION
There is a small typo in README.md.

Should read `retrieve` rather than `retreve`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md